### PR TITLE
Fixed problem with empty objects in json

### DIFF
--- a/src/Python.php
+++ b/src/Python.php
@@ -69,7 +69,7 @@ class Python {
         // "abc_123.456-789"
         // JSON array (with brackets "[" and "]")
         // JSON object (with brackets "{" and "}")
-        $element = '(null|true|false|[0-9]+|[0-9]+\.[0-9]+|"[a-zA-Z0-9\._\-]*"|\[.*\]|{.+})';
+        $element = '(null|true|false|[0-9]+|[0-9]+\.[0-9]+|"[a-zA-Z0-9\._\-]*"|\[.*\]|{.+}|{})';
 
         // Convert nested tupels ((1, 2), (3, 4)) into arrays:
         $value = preg_replace(

--- a/tests/PythonTest.php
+++ b/tests/PythonTest.php
@@ -673,6 +673,23 @@ EOF
 }
 EOF
                 )
+            ],
+            'Empty objects' => [
+<<<EOF
+{'firstLevel': {}, 'someKey': {'secondLevel': {}}}
+EOF,
+
+                $this->decodeJSON(
+                    <<<EOF
+{
+    "firstLevel": {},
+    "someKey": {
+        "secondLevel": {}
+    }
+}
+EOF
+
+                )
             ]
         ];
     }


### PR DESCRIPTION
Short description

Problem while parsing empty objects in json "{}"

### Changed

-   src/Python.php
  - {} added to list of elements


### Confirmation

By sending this pull request I accept the following conditions:

-   [x] I have read the code of conduct and accept it.
-   [x] I have read the contributing guidelines and accept them.
-   [x] I accept that my contribution will be licensed under the AGPLv3.
