### PR TITLE
Make 'username' configuration optional

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -215,6 +215,12 @@ class API {
         $params['action'] = $action;
         $params['_username'] = $this->config->getUsername();
         $params['_secret'] = $this->config->getSecret();
+
+        // Go sure to not send an empty username.
+        if (trim($params['_username']) === '') {
+            unset($params['_username']);
+        }
+
 // @todo GET parameter "request_format=json" resulted in an error:
 //        $params['request_format'] = 'json';
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -349,7 +349,6 @@ class Config {
 
         $mandatorySettings = [
             'URL' => $this->url,
-            'username' => $this->username,
             'secret' => $this->secret
         ];
 
@@ -378,12 +377,6 @@ class Config {
         } elseif (strpos($this->url, 'http://') === 0) {
             $this->port = self::HTTP_PORT;
         }
-
-        /**
-         * Username
-         */
-
-        $this->assertString('username', $this->username);
 
         /**
          * Secret


### PR DESCRIPTION
Make the 'username' optional

In order to make requests without a 'username' some minor changes needed to be done.

### Added

-   A check if the given username is empty - if so, remove the key from the request.

### Changed

-   Made the 'username' configuration optional.

### Confirmation

By sending this pull request I accept the following conditions:

-   [x] I have read the code of conduct and accept it.
-   [x] I have read the contributing guidelines and accept them.
-   [x] I accept that my contribution will be licensed under the AGPLv3.
