### PR TITLE
Task/php8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Easy-to-use, but feature-rich client for Checkmk Web API
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/bheisig/checkmkwebapi.svg)](https://packagist.org/packages/bheisig/checkmkwebapi)
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.4-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%5E7.4%7C%5E8.0-8892BF.svg)](https://php.net/)
 [![Build Status](https://travis-ci.org/bheisig/checkmkwebapi.svg?branch=master)](https://travis-ci.org/bheisig/checkmkwebapi)
 
 ## About

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Easy-to-use, but feature-rich client for Checkmk Web API
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/bheisig/checkmkwebapi.svg)](https://packagist.org/packages/bheisig/checkmkwebapi)
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.0-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.4-8892BF.svg)](https://php.net/)
 [![Build Status](https://travis-ci.org/bheisig/checkmkwebapi.svg?branch=master)](https://travis-ci.org/bheisig/checkmkwebapi)
 
 ## About
@@ -17,7 +17,7 @@ This client communicates with Checkmk over its Web API. It provides a simple, bu
 Meet these simple requirements before using the client:
 
 -   One or more Checkmk sites, version 1.4 or higher (most calls work since 1.5)
--   PHP, version 7.3 or higher (7.2 still works but is deprecated; 7.4 is recommended)
+-   PHP, version 7.4 or 8.0
 -   PHP modules `curl`, `date`, `json`, `openssl`, `spl` and `zlib`
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "source": "https://github.com/bheisig/checkmkwebapi"
     },
     "require": {
-        "php": ">=7.2.0",
+        "php": "^7.4|^8.0",
         "ext-curl": "*",
         "ext-date": "*",
         "ext-json": "*",

--- a/src/API.php
+++ b/src/API.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace bheisig\checkmkwebapi;
 
+use CurlHandle;
 use \Exception;
 use \RuntimeException;
 
@@ -40,7 +41,7 @@ class API {
     protected $config;
 
     /**
-     * @var resource cURL resource
+     * @var resource|CurlHandle
      */
     protected $resource;
 
@@ -130,7 +131,7 @@ class API {
      * @return bool
      */
     public function isConnected(): bool {
-        return is_resource($this->resource);
+        return is_resource($this->resource) || $this->resource instanceof CurlHandle;
     }
 
     /**


### PR DESCRIPTION
Make the API client compatible to PHP8 :)

### Added

- Nothing

### Changed

- resource handling to support both `resource` and `CurlHandle`

### Fixed

- PHP8 compatibility

### Removed

- Nothing

### Confirmation

By sending this pull request I accept the following conditions:

-   [x] I have read the code of conduct and accept it.
-   [x] I have read the contributing guidelines and accept them.
-   [x] I accept that my contribution will be licensed under the AGPLv3.
